### PR TITLE
📦 NEW: Tool call types

### DIFF
--- a/packages/langbase/src/pipes/pipes.ts
+++ b/packages/langbase/src/pipes/pipes.ts
@@ -5,7 +5,14 @@ export type Role = 'user' | 'assistant' | 'system' | 'tool';
 
 export interface Message {
 	role: Role;
-	content: string;
+	content: string | null;
+	name?: string;
+	tool_call_id?: string;
+	tool_calls?: {
+		id: string;
+		type: 'function';
+		function: Record<string, any>;
+	}[];
 }
 
 export interface GenerateOptions {

--- a/packages/langbase/src/pipes/pipes.ts
+++ b/packages/langbase/src/pipes/pipes.ts
@@ -3,10 +3,15 @@ import {Stream} from '../common/stream';
 
 export type Role = 'user' | 'assistant' | 'system' | 'tool';
 
+export interface Function {
+	name: string;
+	arguments: string;
+}
+
 export interface ToolCall {
 	id: string;
 	type: 'function';
-	function: Record<string, any>;
+	function: Function;
 }
 
 export interface Message {

--- a/packages/langbase/src/pipes/pipes.ts
+++ b/packages/langbase/src/pipes/pipes.ts
@@ -3,16 +3,18 @@ import {Stream} from '../common/stream';
 
 export type Role = 'user' | 'assistant' | 'system' | 'tool';
 
+export interface ToolCall {
+	id: string;
+	type: 'function';
+	function: Record<string, any>;
+}
+
 export interface Message {
 	role: Role;
 	content: string | null;
 	name?: string;
 	tool_call_id?: string;
-	tool_calls?: {
-		id: string;
-		type: 'function';
-		function: Record<string, any>;
-	}[];
+	tool_calls?: ToolCall[];
 }
 
 export interface GenerateOptions {


### PR DESCRIPTION
This PR adds the following types to `Message` object:

```ts
export interface Message {
	name?: string;
	tool_call_id?: string;
	tool_calls?: {
		id: string;
		type: 'function';
		function: Record<string, any>;
	}[];
}
```

We currently support OpenAI tool calls. When the LLM triggers a tool, the LLM's response includes a tool_calls object in the message. When the user responds to a tool call, they must include the tool's name and tool_call_id in the Message object. 