### PR TITLE
📦 NEW: LLM

### DIFF
--- a/packages/langbase/src/langbase/langbase.ts
+++ b/packages/langbase/src/langbase/langbase.ts
@@ -34,7 +34,7 @@ export interface LlmOptionsBase {
 	presence_penalty?: number;
 	frequency_penalty?: number;
 	stop?: string[];
-	tool_choice?: any;
+	tool_choice?: 'auto' | 'required' | ToolChoice;
 	parallel_tool_calls?: boolean;
 	customModelParams?: Record<string, any>;
 }


### PR DESCRIPTION
This PR adds the `langbase.llm()` function.

### Usage

It is completely runtime, so provide all parameters, messages, and llm API key with the function. For example:

```ts
	// 1. Initiate
	const langbase = new Langbase({
		apiKey: process.env.LANGBASE_API_KEY!,
	});

	// 2. Generate a stream by asking a question
	const result = await langbase.llm({
		messages: [
			{role: 'system', content: 'You are a helpful assistant.'},
			{role: 'user', content: "What is 2+2?"}],
		model: 'openai:gpt-4o-mini',
		llmKey: '',
		stream: false,
	});
```

`llmKey`, `model`, and `llmKey` are required variables. See types for more options.


