### PR TITLE
📦 NEW: Make workflow config object

### DIFF
--- a/packages/langbase/src/langbase/langbase.ts
+++ b/packages/langbase/src/langbase/langbase.ts
@@ -640,7 +640,7 @@ export class Langbase {
 		};
 	};
 
-	public workflow: (config: {debug?: boolean; name?: string}) => Workflow;
+	public workflow: (config?: {debug?: boolean; name?: string}) => Workflow;
 
 	public traces: {
 		create: (trace: any) => Promise<any>;
@@ -731,7 +731,8 @@ export class Langbase {
 			run: this.runAgent.bind(this),
 		};
 
-		this.workflow = config => new Workflow({...config, langbase: this});
+		this.workflow = (config = {}) =>
+			new Workflow({...config, langbase: this});
 
 		this.traces = {
 			create: this.createTrace.bind(this),

--- a/packages/langbase/src/langbase/workflows.ts
+++ b/packages/langbase/src/langbase/workflows.ts
@@ -58,11 +58,11 @@ export class Workflow {
 	private originalMethods: Map<string, Function> = new Map();
 	public readonly step: <T = any>(config: StepConfig<T>) => Promise<T>;
 
-	constructor(config: WorkflowConfig) {
+	constructor(config?: WorkflowConfig) {
 		this.context = {outputs: {}};
-		this.debug = config.debug ?? false;
-		this.name = config.name ?? 'workflow';
-		this.langbase = config.langbase;
+		this.debug = config?.debug ?? false;
+		this.name = config?.name ?? 'workflow';
+		this.langbase = config?.langbase;
 
 		// Only initialize tracing if langbase is provided
 		if (this.langbase) {

--- a/packages/langbase/src/langbase/workflows.ts
+++ b/packages/langbase/src/langbase/workflows.ts
@@ -131,10 +131,11 @@ export class Workflow {
 
 						// Notify collector if traceId was found
 						if (traceId && _global._activeTraceCollector) {
-							if (debug)
+							if (debug) {
 								console.log(
 									`🔍 Trace ID extracted: ${traceId}`,
 								);
+							}
 							_global._activeTraceCollector(traceId);
 						}
 					}
@@ -391,7 +392,9 @@ export class Workflow {
 		if (!this.langbase || !this.traceManager || !this.traceId) return;
 		// Finalise and grab the trace
 		this.traceManager.endTrace(this.traceId);
-		this.traceManager.printTrace(this.traceId);
+		if (this.debug) {
+			this.traceManager.printTrace(this.traceId);
+		}
 		const traceData = this.traceManager.getTrace(this.traceId);
 
 		// --- send to LB API v1/traces/create using SDK method ---


### PR DESCRIPTION
This PR makes the `Workflow` config object optional so we do not have to pass `debug: false` flag if we do not require debug logs.